### PR TITLE
Fix link shadow

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -9,7 +9,8 @@ body {
 }
 
 a {
-    text-shadow: 0 0 5px #800080;
+    text-shadow: 0 0 2px #000000;
+    color: #00008b;
 }
 
 .page-content {


### PR DESCRIPTION
Update the link shadow and color to make it easier for the eyes.

* Change the text-shadow property of the `a` selector to `0 0 2px #000000`
* Change the color property of the `a` selector to `#00008b`

